### PR TITLE
Include generate_local_binary configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ type = library
 ; Flag denoting whether to generate a BUILD file.
 ; generate_build_file = true
 
+; Flag denoting whether to generate a python_binary target for local.py. This is
+; essentially an extra entry point. It's only used for specific package types.
+; generate_pytest_binary = false
+
 ; Flag denoting whether to include a python_binary target for pytest
 ; generate_pytest_binary = false
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ type = library
 
 ; Flag denoting whether to generate a python_binary target for local.py. This is
 ; essentially an extra entry point. It's only used for specific package types.
-; generate_pytest_binary = false
+; generate_local_binary = false
 
 ; Flag denoting whether to include a python_binary target for pytest
 ; generate_pytest_binary = false

--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/pypants/build_targets/lambda_function.py
+++ b/src/pypants/build_targets/lambda_function.py
@@ -25,7 +25,7 @@ class PythonLambdaPackage(PythonBinaryPackage):
         return f"{self.key}:lib"
 
     def _generate_python_binary_cli_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target"""
+        """Generate an AST node for a python_binary Pants target that runs lambda_handler.py"""  # noqa
         node = ast.Expr(
             value=ast.Call(
                 func=ast.Name(id="python_binary"),
@@ -69,13 +69,14 @@ class PythonLambdaPackage(PythonBinaryPackage):
 
     def generate_build_file_ast_node(self) -> ast.Module:
         """Generate a Pants BUILD file as an AST module node"""
-        node = ast.Module(
-            body=[
-                self._generate_python_library_ast_node(
-                    name="lib", globs_path=f"{self.package_name}/**/*"
-                ),
-                self._generate_python_binary_cli_ast_node(),
-                self._generate_python_lambda_ast_node(),
-            ]
-        )
+        body = [
+            self._generate_python_library_ast_node(
+                name="lib", globs_path=f"{self.package_name}/**/*"
+            ),
+            self._generate_python_binary_cli_ast_node(),
+            self._generate_python_lambda_ast_node(),
+        ]
+        if self.config.generate_local_binary:
+            body.append(self._generate_python_binary_local_ast_node())
+        node = ast.Module(body=body)
         return node

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -28,6 +28,7 @@ class Config:
         extra_dependencies = ["lib/python_core/src", ...]
         extra_tags = ["my-tag", ...]
         generate_build_file = <bool>
+        generate_local_binary = <bool>
         generate_pytest_binary = <bool>
         include_test_coverage = <bool>
         type = "library"|"binary"|...
@@ -120,6 +121,13 @@ class Config:
     def generate_build_file(self) -> bool:
         """Flag denoting whether to generate a BUILD file"""
         return self._config.getboolean("package", "generate_build_file", fallback=True)
+
+    @property
+    def generate_local_binary(self) -> bool:
+        """Flag denoting whether to generate a python_binary target for local.py"""
+        return self._config.getboolean(
+            "package", "generate_local_binary", fallback=False
+        )
 
     @property
     def generate_pytest_binary(self) -> bool:


### PR DESCRIPTION
@ns-bdesimone @ns-cweber  

Includes an option to generate another python_binary target that we need for py2sfn local development