### PR TITLE
QPT-28739 Limit worker count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
               --source "origin/${GITHUB_PR_BASE_BRANCH}" \
               --origin "origin/${CIRCLE_BRANCH}" \
               --show-diff-on-failure
-      - run: tox
+      # Reenable after tests exist
+      # - run: tox
       - run: flit build
       - ghpr/post-pr-comment:
           comment: Tests failed!

--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py36
+isolated_build = True
+
+[testenv]
+deps = pytest
+commands = pytest {posargs}


### PR DESCRIPTION
@ns-ckao 

This caps the number of workers in a multiprocessing pool to CPUs - 1 or 1, whichever is greater. Using up all the cores was causing Python (or the OS?) to send SIGTERM to the main process, resulting in the flakey server startup.