### PR TITLE
Pin cookiecutter to 1.7.0 (1.7.1 breaks stuff)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "astor<1,>=0.7.1",
     "black==19.3b0",
     "Click>=7.0",
-    "cookiecutter=1.7.0",
+    "cookiecutter==1.7.0",
     "networkx<3,>=2.2",
     "python-slugify<2,>=1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "astor<1,>=0.7.1",
     "black==19.3b0",
     "Click>=7.0",
-    "cookiecutter<2,>=1.6.0",
+    "cookiecutter=1.7.0",
     "networkx<3,>=2.2",
     "python-slugify<2,>=1.2.0",
 ]

--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
TL:DR: Cookiecutter 1.7.1 is causing dependency issues upstream.
See QPT-29723 for details