### PR TITLE
QUALITY-1864 - Add the check for include test coverage

### DIFF
--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/pypants/build_targets/test.py
+++ b/src/pypants/build_targets/test.py
@@ -34,7 +34,8 @@ class PythonTestPackage(PythonPackage):
                 code_target_package_names = {
                     d.package_name
                     for d in self.dependencies
-                    if not isinstance(d, PythonRequirement) and d.config.include_test_coverage
+                    if not isinstance(d, PythonRequirement)
+                    and d.config.include_test_coverage
                 }
                 # Build the coverage based on the dependency packages
                 elements = [ast.Str(pkg) for pkg in sorted(code_target_package_names)]

--- a/src/pypants/build_targets/test.py
+++ b/src/pypants/build_targets/test.py
@@ -34,7 +34,7 @@ class PythonTestPackage(PythonPackage):
                 code_target_package_names = {
                     d.package_name
                     for d in self.dependencies
-                    if not isinstance(d, PythonRequirement)
+                    if not isinstance(d, PythonRequirement) and d.config.include_test_coverage
                 }
                 # Build the coverage based on the dependency packages
                 elements = [ast.Str(pkg) for pkg in sorted(code_target_package_names)]


### PR DESCRIPTION
Add the check for include_test_coverage when generating coverage information for pytest component and content.