### PR TITLE
QPT-32691: Non Zip Safe Binary Targets

### DIFF
--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/pypants/build_targets/binary.py
+++ b/src/pypants/build_targets/binary.py
@@ -99,7 +99,9 @@ class PythonBinaryPackage(PythonPackage):
                         arg="sources",
                         value=ast.List(elts=[ast.Str(source_module_path)]),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
+                    ast.keyword(
+                        arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)
+                    ),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/binary.py
+++ b/src/pypants/build_targets/binary.py
@@ -99,7 +99,7 @@ class PythonBinaryPackage(PythonPackage):
                         arg="sources",
                         value=ast.List(elts=[ast.Str(source_module_path)]),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
+                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/binary.py
+++ b/src/pypants/build_targets/binary.py
@@ -99,6 +99,7 @@ class PythonBinaryPackage(PythonPackage):
                         arg="sources",
                         value=ast.List(elts=[ast.Str(source_module_path)]),
                     ),
+                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/lambda_function.py
+++ b/src/pypants/build_targets/lambda_function.py
@@ -45,6 +45,7 @@ class PythonLambdaPackage(PythonBinaryPackage):
                         arg="entry_point",
                         value=ast.Str(f"{self.package_name}/lambda_handler.py"),
                     ),
+                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/lambda_function.py
+++ b/src/pypants/build_targets/lambda_function.py
@@ -45,7 +45,9 @@ class PythonLambdaPackage(PythonBinaryPackage):
                         arg="entry_point",
                         value=ast.Str(f"{self.package_name}/lambda_handler.py"),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
+                    ast.keyword(
+                        arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)
+                    ),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/lambda_function.py
+++ b/src/pypants/build_targets/lambda_function.py
@@ -45,7 +45,7 @@ class PythonLambdaPackage(PythonBinaryPackage):
                         arg="entry_point",
                         value=ast.Str(f"{self.package_name}/lambda_handler.py"),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
+                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
                     self._tags_keyword,
                 ],
             )

--- a/src/pypants/build_targets/python_package.py
+++ b/src/pypants/build_targets/python_package.py
@@ -277,7 +277,7 @@ class PythonPackage(BuildTarget):
                         arg="dependencies",
                         value=ast.List(elts=[ast.Str(d) for d in dependencies]),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
+                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
                 ],
             )
         )

--- a/src/pypants/build_targets/python_package.py
+++ b/src/pypants/build_targets/python_package.py
@@ -277,7 +277,9 @@ class PythonPackage(BuildTarget):
                         arg="dependencies",
                         value=ast.List(elts=[ast.Str(d) for d in dependencies]),
                     ),
-                    ast.keyword(arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)),
+                    ast.keyword(
+                        arg="zip_safe", value=ast.NameConstant(self.config.zip_safe)
+                    ),
                 ],
             )
         )

--- a/src/pypants/build_targets/python_package.py
+++ b/src/pypants/build_targets/python_package.py
@@ -277,6 +277,7 @@ class PythonPackage(BuildTarget):
                         arg="dependencies",
                         value=ast.List(elts=[ast.Str(d) for d in dependencies]),
                     ),
+                    ast.keyword(arg="zip_safe", value=ast.Str(self.config.zip_safe)),
                 ],
             )
         )

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -164,6 +164,11 @@ class Config:
         """Resource glob path if needed in a package"""
         return self._config.get("package", "resource_glob_path", fallback=None)
 
+    @property
+    def zip_safe(self) -> bool:
+        """Default options for zip safe in pants binary targets"""
+        return self._config.get("package", "zip_safe", fallback=False)
+
 
 # Create a singleton for the project configuration
 PROJECT_CONFIG = Config(get_git_top_level_path())

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -167,7 +167,7 @@ class Config:
     @property
     def zip_safe(self) -> bool:
         """Default options for zip safe in pants binary targets"""
-        return self._config.get("package", "zip_safe", fallback=False)
+        return self._config.getboolean("package", "zip_safe", fallback=False)
 
 
 # Create a singleton for the project configuration


### PR DESCRIPTION
# Overview:
This PR shuts off zip safe by default in all binary targets. This is configurable through the pypants.cfg file for each package if you wish to override.