### PR TITLE
QPT-32631: Pants 2.0.0 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ghpr: narrativescience/ghpr@0.0.5
+  ghpr: narrativescience/ghpr@1.1.1
 
 commands:
   install-deps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 **/__pycache__/
 **/.cache/
 **/.tox
-**/*.
-coverage
+**/*.coverage
 **/*.egg-info
 **/*.pyc
 **/dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 **/__pycache__/
 **/.cache/
 **/.tox
-**/*.coverage
+**/*.
+coverage
 **/*.egg-info
 **/*.pyc
 **/dist

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ type = library
 ; Flag denoting whether to generate a BUILD file.
 ; generate_build_file = true
 
-; Flag denoting whether to generate a python_binary target for local.py. This is
+; Flag denoting whether to generate a pex_binary target for local.py. This is
 ; essentially an extra entry point. It's only used for specific package types.
 ; generate_local_binary = false
 
-; Flag denoting whether to include a python_binary target for pytest
+; Flag denoting whether to include a pex_binary target for pytest
 ; generate_pytest_binary = false
 
 ; Flag denoting whether to include a coverage attribute on pytest targets
@@ -186,7 +186,7 @@ python_library(
     sources=["cli_deploy/**/*"],
     tags={"apps", "code", "python"},
 )
-python_binary(
+pex_binary(
     name="deploy",
     dependencies=[":lib"],
     source="cli_deploy/cli.py",
@@ -195,7 +195,7 @@ python_binary(
 ```
 
 - The `python_library` target is pretty much the same as an internal Python library package
-- The `python_binary` target defines an explicit name. This is because when we go to build the PEX file, we want to define the filename. In this example, running `./pants binary apps/cli_deploy/src:deploy` will result in `dist/deploy.pex`.
+- The `pex_binary` target defines an explicit name. This is because when we go to build the PEX file, we want to define the filename. In this example, running `./pants binary apps/cli_deploy/src:deploy` will result in `dist/deploy.pex`.
 - The only dependency for the binary should be the library. The library will then include all the dependencies.
 - `source` points to the entry point of the binary. This module should handle the `if __name__ == "__main__"` condition to kick off the script.
 
@@ -219,7 +219,7 @@ python_tests(
     sources=["**/*.py"],
     tags={"lib", "python", "tests", "unit"},
 )
-python_binary(
+pex_binary(
     name="unittest",
     entry_point="unittest",
     dependencies=[":lib/time_utils/tests/unit"]
@@ -228,11 +228,11 @@ python_binary(
 
 - The `python_library` target is mostly here to define the unit tests dependencies in a single place so the other two targets can point to it
 - The `python_tests` target lets us run pytest against the test files that match `**/*.py`
-- The `python_binary` target lets us run the unittest module directly. We won't actually package up this target via `./pants binary`. Setting the entry_point to `"unittest"` is essentially the same as running `python -m unittest test_something.py` from the command line.
+- The `pex_binary` target lets us run the unittest module directly. We won't actually package up this target via `./pants binary`. Setting the entry_point to `"unittest"` is essentially the same as running `python -m unittest test_something.py` from the command line.
 
 #### `lambda_function`
 
-The BUILD file for the Lambda handler contains a special-purpose build target: `python_awslambda`. This target is a wrapper around [lambdex](https://github.com/wickman/lambdex). It creates a PEX like the `python_binary` target (you can execute it) but it modifies the PEX to work with a Lambda Function. For example:
+The BUILD file for the Lambda handler contains a special-purpose build target: `python_awslambda`. This target is a wrapper around [lambdex](https://github.com/wickman/lambdex). It creates a PEX like the `pex_binary` target (you can execute it) but it modifies the PEX to work with a Lambda Function. For example:
 
 ```python
 python_library(
@@ -243,7 +243,7 @@ python_library(
         "lib/logger/src",
     ],
 )
-python_binary(
+pex_binary(
     name="my-lambda-bin",
     source="lambda_handler/lambda_handler.py",
     dependencies=[":my-lambda-lib"],
@@ -272,7 +272,7 @@ python_library(
     sources=["**/*"],
     tags={"code", "db", "migration", "python"},
 )
-python_binary(name="alembic", entry_point="alembic.config", dependencies=[":lib"])
+pex_binary(name="alembic", entry_point="alembic.config", dependencies=[":lib"])
 python_app(
     name="migrations-my-database-name",
     archive="tar",
@@ -302,7 +302,7 @@ python_library(
     sources=["**/*"],
     tags={"integration", "python", "tests", "tests-integration"},
 )
-python_binary(
+pex_binary(
     source="behave_cli.py",
     dependencies=[":lib"],
     tags={"integration", "python", "tests", "tests-integration"},

--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ type = library
 ; Flag denoting whether to include a pex_binary target for pytest
 ; generate_pytest_binary = false
 
-; Flag denoting whether to include a coverage attribute on pytest targets
-; include_test_coverage = true
 ```
 
 ### Package Types

--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "1.0.1"
+__version__ = "2.0.1"

--- a/src/pypants/build_targets/behave_.py
+++ b/src/pypants/build_targets/behave_.py
@@ -7,11 +7,11 @@ from .test import PythonTestPackage
 class PythonBehaveTestPackage(PythonTestPackage):
     """Represents a Python test package build target in Pants that uses behave"""
 
-    def _generate_python_binary_behave_wrapper_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that wraps behave"""
+    def _generate_pex_binary_behave_wrapper_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that wraps behave"""
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(
@@ -31,7 +31,7 @@ class PythonBehaveTestPackage(PythonTestPackage):
         node = ast.Module(
             body=[
                 self._generate_python_library_ast_node(name="lib"),
-                self._generate_python_binary_behave_wrapper_node(),
+                self._generate_pex_binary_behave_wrapper_node(),
                 self._generate_python_library_resources_ast_node(),
             ]
         )

--- a/src/pypants/build_targets/binary.py
+++ b/src/pypants/build_targets/binary.py
@@ -83,12 +83,12 @@ class PythonBinaryPackage(PythonPackage):
         )
         return binary_name, source_module_path
 
-    def _generate_python_binary_cli_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target"""
+    def _generate_pex_binary_cli_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target"""
         binary_name, source_module_path = self._parse_entry_point()
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str(binary_name)),
@@ -108,11 +108,11 @@ class PythonBinaryPackage(PythonPackage):
         )
         return node
 
-    def _generate_python_binary_local_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that runs local.py"""
+    def _generate_pex_binary_local_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that runs local.py"""
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str("local")),
@@ -138,10 +138,10 @@ class PythonBinaryPackage(PythonPackage):
             self._generate_python_library_ast_node(
                 name="lib", globs_path=f"{self.package_name}/**/*.py"
             ),
-            self._generate_python_binary_cli_ast_node(),
+            self._generate_pex_binary_cli_ast_node(),
         ]
         if self.config.generate_local_binary:
-            body.append(self._generate_python_binary_local_ast_node())
+            body.append(self._generate_pex_binary_local_ast_node())
         if self.config.resource_glob_path:
             body.append(self._generate_python_library_resources_ast_node())
         node = ast.Module(body=body)

--- a/src/pypants/build_targets/binary.py
+++ b/src/pypants/build_targets/binary.py
@@ -115,7 +115,10 @@ class PythonBinaryPackage(PythonPackage):
                 func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
-                    ast.keyword(arg="name", value=ast.Str("local")),
+                    ast.keyword(
+                        arg="name",
+                        value=ast.Str(f"local-{self.package_name.rsplit('_', 1)[1]}"),
+                    ),
                     ast.keyword(
                         arg="dependencies",
                         value=ast.List(

--- a/src/pypants/build_targets/lambda_function.py
+++ b/src/pypants/build_targets/lambda_function.py
@@ -24,11 +24,11 @@ class PythonLambdaPackage(PythonBinaryPackage):
         """
         return f"{self.key}:lib"
 
-    def _generate_python_binary_cli_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that runs lambda_handler.py"""  # noqa
+    def _generate_pex_binary_cli_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that runs lambda_handler.py"""  # noqa
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str("bin")),
@@ -87,10 +87,10 @@ class PythonLambdaPackage(PythonBinaryPackage):
             self._generate_python_library_ast_node(
                 name="lib", globs_path=f"{self.package_name}/**/*.py"
             ),
-            self._generate_python_binary_cli_ast_node(),
+            self._generate_pex_binary_cli_ast_node(),
             self._generate_python_lambda_ast_node(),
         ]
         if self.config.generate_local_binary:
-            body.append(self._generate_python_binary_local_ast_node())
+            body.append(self._generate_pex_binary_local_ast_node())
         node = ast.Module(body=body)
         return node

--- a/src/pypants/build_targets/migration.py
+++ b/src/pypants/build_targets/migration.py
@@ -45,7 +45,7 @@ class AlembicMigrationPackage(PythonPackage):
         node = ast.Module(
             body=[
                 self._generate_python_library_ast_node(name="lib"),
-                self._generate_python_binary_wrapper_node(
+                self._generate_pex_binary_wrapper_node(
                     "alembic", entry_point="alembic.config", dependencies=[":lib"]
                 ),
                 self._generate_migrations_python_app_ast_node(),

--- a/src/pypants/build_targets/python_package.py
+++ b/src/pypants/build_targets/python_package.py
@@ -243,15 +243,15 @@ class PythonPackage(BuildTarget):
         )
         return node
 
-    def _generate_python_binary_wrapper_node(
+    def _generate_pex_binary_wrapper_node(
         self,
         name: str,
         entry_point: Optional[str] = None,
         dependencies: Optional[List[str]] = None,
     ) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target with an entry point
+        """Generate an AST node for a pex_binary Pants target with an entry point
 
-        See: https://www.pantsbuild.org/python_readme.html#python_binary-entry_point
+        See: https://www.pantsbuild.org/python_readme.html#pex_binary-entry_point
 
         Args:
             name: Name of the binary, e.g. unittest
@@ -268,7 +268,7 @@ class PythonPackage(BuildTarget):
 
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str(name)),

--- a/src/pypants/build_targets/test.py
+++ b/src/pypants/build_targets/test.py
@@ -54,13 +54,13 @@ class PythonTestPackage(PythonPackage):
                 name=self.rendered_package_name, include_extra_dependencies=True
             ),
             self._generate_python_tests_ast_node(),
-            self._generate_python_binary_wrapper_node(
+            self._generate_pex_binary_wrapper_node(
                 "unittest", dependencies=[f":{self.rendered_package_name}"]
             ),
         ]
         if self.config.generate_pytest_binary:
             body.append(
-                self._generate_python_binary_wrapper_node(
+                self._generate_pex_binary_wrapper_node(
                     "pytest", dependencies=[f":{self.rendered_package_name}"]
                 )
             )

--- a/src/pypants/build_targets/test.py
+++ b/src/pypants/build_targets/test.py
@@ -2,7 +2,6 @@
 import ast
 
 from .python_package import PythonPackage
-from .requirement import PythonRequirement
 
 
 class PythonTestPackage(PythonPackage):
@@ -27,21 +26,6 @@ class PythonTestPackage(PythonPackage):
             ast.keyword(arg="sources", value=ast.List(elts=[ast.Str("**/*.py")])),
             self._tags_keyword,
         ]
-        if self.config.include_test_coverage:
-            if self.code_target_package_name is None:
-                # Go through the python_library dependencies and get the package names
-                # Do not include 3rdparty packages
-                code_target_package_names = {
-                    d.package_name
-                    for d in self.dependencies
-                    if not isinstance(d, PythonRequirement)
-                    and d.config.include_test_coverage
-                }
-                # Build the coverage based on the dependency packages
-                elements = [ast.Str(pkg) for pkg in sorted(code_target_package_names)]
-            else:
-                elements = [ast.Str(self.code_target_package_name)]
-            keywords.append(ast.keyword(arg="coverage", value=ast.List(elts=elements)))
         node = ast.Expr(
             value=ast.Call(func=ast.Name(id="python_tests"), args=[], keywords=keywords)
         )

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -125,14 +125,14 @@ class Config:
 
     @property
     def generate_local_binary(self) -> bool:
-        """Flag denoting whether to generate a python_binary target for local.py"""
+        """Flag denoting whether to generate a pex_binary target for local.py"""
         return self._config.getboolean(
             "package", "generate_local_binary", fallback=False
         )
 
     @property
     def generate_pytest_binary(self) -> bool:
-        """Flag denoting whether to include a python_binary target for pytest"""
+        """Flag denoting whether to include a pex_binary target for pytest"""
         return self._config.getboolean(
             "package", "generate_pytest_binary", fallback=False
         )

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -31,7 +31,6 @@ class Config:
         generate_build_file = <bool>
         generate_local_binary = <bool>
         generate_pytest_binary = <bool>
-        include_test_coverage = <bool>
         type = "library"|"binary"|...
 
     Instantiating this class will load and initialize a config parser instance.
@@ -135,13 +134,6 @@ class Config:
         """Flag denoting whether to include a pex_binary target for pytest"""
         return self._config.getboolean(
             "package", "generate_pytest_binary", fallback=False
-        )
-
-    @property
-    def include_test_coverage(self) -> bool:
-        """Flag denoting whether to include a coverage attribute on pytest targets"""
-        return self._config.getboolean(
-            "package", "include_test_coverage", fallback=True
         )
 
     @property


### PR DESCRIPTION
# Overview:
This enables pants 2.0.1rc4 support in pypants. 

## New features and Changes:
- [x] python_binary deprecation -> pex_binary
- [x] python_test goal with `coverage' deprecation
- [x] python local binary goal now includes package name appended to it with '-' where '_' was used.

## Additional Changes:
* bumping ghpr orb in cci to get latest changes