### PR TITLE
QPT-33058: Pants 2.0.0 Coverage Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ type = library
 ; Flag denoting whether to include a pex_binary target for pytest
 ; generate_pytest_binary = false
 
-; Flag denoting whether to include a coverage attribute on pytest targets
-; include_test_coverage = true
 ```
 
 ### Package Types

--- a/src/pypants/build_targets/test.py
+++ b/src/pypants/build_targets/test.py
@@ -2,7 +2,6 @@
 import ast
 
 from .python_package import PythonPackage
-from .requirement import PythonRequirement
 
 
 class PythonTestPackage(PythonPackage):
@@ -27,21 +26,6 @@ class PythonTestPackage(PythonPackage):
             ast.keyword(arg="sources", value=ast.List(elts=[ast.Str("**/*.py")])),
             self._tags_keyword,
         ]
-        if self.config.include_test_coverage:
-            if self.code_target_package_name is None:
-                # Go through the python_library dependencies and get the package names
-                # Do not include 3rdparty packages
-                code_target_package_names = {
-                    d.package_name
-                    for d in self.dependencies
-                    if not isinstance(d, PythonRequirement)
-                    and d.config.include_test_coverage
-                }
-                # Build the coverage based on the dependency packages
-                elements = [ast.Str(pkg) for pkg in sorted(code_target_package_names)]
-            else:
-                elements = [ast.Str(self.code_target_package_name)]
-            keywords.append(ast.keyword(arg="coverage", value=ast.List(elts=elements)))
         node = ast.Expr(
             value=ast.Call(func=ast.Name(id="python_tests"), args=[], keywords=keywords)
         )

--- a/src/pypants/config.py
+++ b/src/pypants/config.py
@@ -31,7 +31,6 @@ class Config:
         generate_build_file = <bool>
         generate_local_binary = <bool>
         generate_pytest_binary = <bool>
-        include_test_coverage = <bool>
         type = "library"|"binary"|...
 
     Instantiating this class will load and initialize a config parser instance.
@@ -135,13 +134,6 @@ class Config:
         """Flag denoting whether to include a pex_binary target for pytest"""
         return self._config.getboolean(
             "package", "generate_pytest_binary", fallback=False
-        )
-
-    @property
-    def include_test_coverage(self) -> bool:
-        """Flag denoting whether to include a coverage attribute on pytest targets"""
-        return self._config.getboolean(
-            "package", "include_test_coverage", fallback=True
         )
 
     @property


### PR DESCRIPTION
# Overview:
Pants 2.0.0 turns off coverage in individual BIULD files. It is now configured at a global level and with command line args. Removing the coverage options from the test target BUILD file generators.

# Test:
Tested locally.