### PR TITLE
QPT-33649: Pants 2.1.1 Support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # See: https://help.github.com/en/articles/about-code-owners
-* @jdrake
+* @jdrake @ns-bdesimone @NarrativeScience/cloud-eng-approved

--- a/src/pypants/__init__.py
+++ b/src/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "2.0.1"
+__version__ = "2.1.1"

--- a/src/pypants/build_targets/migration.py
+++ b/src/pypants/build_targets/migration.py
@@ -1,5 +1,6 @@
 """Contains AlembicMigrationPackage class"""
 import ast
+from typing import List
 
 from .python_package import PythonPackage
 
@@ -7,34 +8,38 @@ from .python_package import PythonPackage
 class AlembicMigrationPackage(PythonPackage):
     """Represents an Alembic database migration bundle target in Pants"""
 
-    def _generate_bundle_item(self, glob: str) -> ast.Call:
-        """Generate an AST node for a bundle item for use in a python_app target"""
-        return ast.Call(
-            func=ast.Name(id="bundle"),
-            args=[],
-            keywords=[ast.keyword(arg="fileset", value=ast.List(elts=[ast.Str(glob)]))],
-        )
-
-    def _generate_migrations_python_app_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_app Pants target that bundles migrations"""
+    def _generate_migrations_archive_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a archive Pants target that bundles migrations"""
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_app"),
+                func=ast.Name(id="archive"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str(self.package_name)),
-                    ast.keyword(arg="archive", value=ast.Str("tar")),
-                    ast.keyword(arg="binary", value=ast.Str(":alembic")),
+                    ast.keyword(arg="format", value=ast.Str("tar")),
                     ast.keyword(
-                        arg="bundles",
-                        value=ast.List(
-                            elts=[
-                                self._generate_bundle_item(glob)
-                                for glob in ["alembic.ini", "env.py", "versions/*.py"]
-                            ]
-                        ),
+                        arg="packages", value=ast.List(elts=[ast.Str(":alembic")])
                     ),
+                    ast.keyword(arg="files", value=ast.List(elts=[ast.Str(":files")])),
                     self._tags_keyword,
+                ],
+            )
+        )
+        return node
+
+    def _generate_migrations_files_ast_node(self, sources: List[str]) -> ast.Expr:
+        """Generate an AST node for a files Pants target that bundles migration files"""
+        # Turn our list of sources into an ast list of ast strings
+        ast_sources = []
+        for source in sources:
+            ast_sources.append(ast.Str(source))
+        node = ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="files"),
+                args=[],
+                keywords=[
+                    ast.keyword(arg="name", value=ast.Str("files")),
+                    ast.keyword(arg="sources", value=ast.List(elts=ast_sources)),
                 ],
             )
         )
@@ -48,7 +53,10 @@ class AlembicMigrationPackage(PythonPackage):
                 self._generate_pex_binary_wrapper_node(
                     "alembic", entry_point="alembic.config", dependencies=[":lib"]
                 ),
-                self._generate_migrations_python_app_ast_node(),
+                self._generate_migrations_archive_ast_node(),
+                self._generate_migrations_files_ast_node(
+                    sources=["alembic.ini", "env.py", "versions/*.py"]
+                ),
             ]
         )
         return node


### PR DESCRIPTION
# Overview:
This PR adds the support for pants 2.1.1 into pypants. Some main changes and features:
* python_app targets changed to archive targets in BUILD files.
* Migration targets use the new archives

## Other Updates:
Codeowners bumped to include myslef and the rest of the cloud-eng code approvers