### PR TITLE
Use absolute paths for file crawling

### DIFF
--- a/pypants/__init__.py
+++ b/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "1.30.0"
+__version__ = "1.30.1"

--- a/pypants/process_packages.py
+++ b/pypants/process_packages.py
@@ -145,8 +145,9 @@ class PackageProcessor:
 
         setup_py_paths: List[Tuple[str, Path]] = []
         for top_dir_name in PROJECT_CONFIG.top_dirs:
-            logger.debug(f"Walking {top_dir_name}")
-            for dirpath, dirnames, filenames in os.walk(top_dir_name):
+            top_dir = Path(PROJECT_CONFIG.config_dir_path).joinpath(top_dir_name)
+            logger.debug(f"Walking {top_dir}")
+            for dirpath, dirnames, filenames in os.walk(top_dir):
                 if os.path.basename(dirpath) in PROJECT_CONFIG.ignore_dirs:
                     # Empty the list of directories so os.walk does not recur
                     dirnames.clear()
@@ -198,10 +199,16 @@ class PackageProcessor:
                 target_type="code",
                 build_template=top_dir_name,
                 top_dir_name=top_dir_name,
-                package_dir_name=str(setup_py_path.parent.relative_to(top_dir_name)),
+                package_dir_name=str(
+                    setup_py_path.parent.relative_to(
+                        Path(PROJECT_CONFIG.config_dir_path).joinpath(top_dir_name)
+                    )
+                ),
                 package_path=src_entry.path,
                 package_name=package_name,
-                build_dir=str(src_dir),
+                build_dir=str(
+                    src_dir.relative_to(Path(PROJECT_CONFIG.config_dir_path))
+                ),
                 config=config,
             )
             if target.key in PROJECT_CONFIG.ignore_targets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypants"
-version = "1.30.0"
+version = "1.30.1"
 description = "CLI for working with Python packages and BUILD files in a Pants monorepo"
 authors = ["Jonathan Drake <jdrake@narrativescience.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
I don't know why this changed, but during tests I was seeing that pypants wasn't finding any setup.py files when it crawled the repo. Using absolute paths seemed to fix things. 