### PR TITLE
QPT-35680: Support Pants 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,13 @@ type = library
 ; Flag denoting whether to generate a BUILD file.
 ; generate_build_file = true
 
-; Flag denoting whether to generate a python_binary target for local.py. This is
+; Flag denoting whether to generate a pex_binary target for local.py. This is
 ; essentially an extra entry point. It's only used for specific package types.
 ; generate_local_binary = false
 
-; Flag denoting whether to include a python_binary target for pytest
+; Flag denoting whether to include a pex_binary target for pytest
 ; generate_pytest_binary = false
 
-; Flag denoting whether to include a coverage attribute on pytest targets
-; include_test_coverage = true
 ```
 
 ### Package Types
@@ -186,7 +184,7 @@ python_library(
     sources=["cli_deploy/**/*"],
     tags={"apps", "code", "python"},
 )
-python_binary(
+pex_binary(
     name="deploy",
     dependencies=[":lib"],
     source="cli_deploy/cli.py",
@@ -195,7 +193,7 @@ python_binary(
 ```
 
 - The `python_library` target is pretty much the same as an internal Python library package
-- The `python_binary` target defines an explicit name. This is because when we go to build the PEX file, we want to define the filename. In this example, running `./pants binary apps/cli_deploy/src:deploy` will result in `dist/deploy.pex`.
+- The `pex_binary` target defines an explicit name. This is because when we go to build the PEX file, we want to define the filename. In this example, running `./pants binary apps/cli_deploy/src:deploy` will result in `dist/deploy.pex`.
 - The only dependency for the binary should be the library. The library will then include all the dependencies.
 - `source` points to the entry point of the binary. This module should handle the `if __name__ == "__main__"` condition to kick off the script.
 
@@ -219,7 +217,7 @@ python_tests(
     sources=["**/*.py"],
     tags={"lib", "python", "tests", "unit"},
 )
-python_binary(
+pex_binary(
     name="unittest",
     entry_point="unittest",
     dependencies=[":lib/time_utils/tests/unit"]
@@ -228,11 +226,11 @@ python_binary(
 
 - The `python_library` target is mostly here to define the unit tests dependencies in a single place so the other two targets can point to it
 - The `python_tests` target lets us run pytest against the test files that match `**/*.py`
-- The `python_binary` target lets us run the unittest module directly. We won't actually package up this target via `./pants binary`. Setting the entry_point to `"unittest"` is essentially the same as running `python -m unittest test_something.py` from the command line.
+- The `pex_binary` target lets us run the unittest module directly. We won't actually package up this target via `./pants binary`. Setting the entry_point to `"unittest"` is essentially the same as running `python -m unittest test_something.py` from the command line.
 
 #### `lambda_function`
 
-The BUILD file for the Lambda handler contains a special-purpose build target: `python_awslambda`. This target is a wrapper around [lambdex](https://github.com/wickman/lambdex). It creates a PEX like the `python_binary` target (you can execute it) but it modifies the PEX to work with a Lambda Function. For example:
+The BUILD file for the Lambda handler contains a special-purpose build target: `python_awslambda`. This target is a wrapper around [lambdex](https://github.com/wickman/lambdex). It creates a PEX like the `pex_binary` target (you can execute it) but it modifies the PEX to work with a Lambda Function. For example:
 
 ```python
 python_library(
@@ -243,7 +241,7 @@ python_library(
         "lib/logger/src",
     ],
 )
-python_binary(
+pex_binary(
     name="my-lambda-bin",
     source="lambda_handler/lambda_handler.py",
     dependencies=[":my-lambda-lib"],
@@ -272,7 +270,7 @@ python_library(
     sources=["**/*"],
     tags={"code", "db", "migration", "python"},
 )
-python_binary(name="alembic", entry_point="alembic.config", dependencies=[":lib"])
+pex_binary(name="alembic", entry_point="alembic.config", dependencies=[":lib"])
 python_app(
     name="migrations-my-database-name",
     archive="tar",
@@ -302,7 +300,7 @@ python_library(
     sources=["**/*"],
     tags={"integration", "python", "tests", "tests-integration"},
 )
-python_binary(
+pex_binary(
     source="behave_cli.py",
     dependencies=[":lib"],
     tags={"integration", "python", "tests", "tests-integration"},

--- a/pypants/__init__.py
+++ b/pypants/__init__.py
@@ -1,3 +1,3 @@
 """CLI for working with Python packages and BUILD files in a Pants monorepo"""
 
-__version__ = "1.30.5"
+__version__ = "2.0.2"

--- a/pypants/build_targets/behave_.py
+++ b/pypants/build_targets/behave_.py
@@ -7,11 +7,11 @@ from .test import PythonTestPackage
 class PythonBehaveTestPackage(PythonTestPackage):
     """Represents a Python test package build target in Pants that uses behave"""
 
-    def _generate_python_binary_behave_wrapper_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that wraps behave"""
+    def _generate_pex_binary_behave_wrapper_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that wraps behave"""
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(
@@ -31,7 +31,7 @@ class PythonBehaveTestPackage(PythonTestPackage):
         node = ast.Module(
             body=[
                 self._generate_python_library_ast_node(name="lib"),
-                self._generate_python_binary_behave_wrapper_node(),
+                self._generate_pex_binary_behave_wrapper_node(),
                 self._generate_python_library_resources_ast_node(),
             ]
         )

--- a/pypants/build_targets/binary.py
+++ b/pypants/build_targets/binary.py
@@ -83,12 +83,12 @@ class PythonBinaryPackage(PythonPackage):
         )
         return binary_name, source_module_path
 
-    def _generate_python_binary_cli_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target"""
+    def _generate_pex_binary_cli_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target"""
         binary_name, source_module_path = self._parse_entry_point()
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str(binary_name)),
@@ -108,11 +108,11 @@ class PythonBinaryPackage(PythonPackage):
         )
         return node
 
-    def _generate_python_binary_local_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that runs local.py"""
+    def _generate_pex_binary_local_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that runs local.py"""
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str("local")),
@@ -138,10 +138,10 @@ class PythonBinaryPackage(PythonPackage):
             self._generate_python_library_ast_node(
                 name="lib", globs_path=f"{self.package_name}/**/*.py"
             ),
-            self._generate_python_binary_cli_ast_node(),
+            self._generate_pex_binary_cli_ast_node(),
         ]
         if self.config.generate_local_binary:
-            body.append(self._generate_python_binary_local_ast_node())
+            body.append(self._generate_pex_binary_local_ast_node())
         if self.config.resource_glob_path:
             body.append(self._generate_python_library_resources_ast_node())
         node = ast.Module(body=body)

--- a/pypants/build_targets/lambda_function.py
+++ b/pypants/build_targets/lambda_function.py
@@ -24,11 +24,11 @@ class PythonLambdaPackage(PythonBinaryPackage):
         """
         return f"{self.key}:lib"
 
-    def _generate_python_binary_cli_ast_node(self) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target that runs lambda_handler.py"""  # noqa
+    def _generate_pex_binary_cli_ast_node(self) -> ast.Expr:
+        """Generate an AST node for a pex_binary Pants target that runs lambda_handler.py"""  # noqa
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str("bin")),
@@ -83,10 +83,10 @@ class PythonLambdaPackage(PythonBinaryPackage):
             self._generate_python_library_ast_node(
                 name="lib", globs_path=f"{self.package_name}/**/*.py"
             ),
-            self._generate_python_binary_cli_ast_node(),
+            self._generate_pex_binary_cli_ast_node(),
             self._generate_python_lambda_ast_node(),
         ]
         if self.config.generate_local_binary:
-            body.append(self._generate_python_binary_local_ast_node())
+            body.append(self._generate_pex_binary_local_ast_node())
         node = ast.Module(body=body)
         return node

--- a/pypants/build_targets/migration.py
+++ b/pypants/build_targets/migration.py
@@ -45,7 +45,7 @@ class AlembicMigrationPackage(PythonPackage):
         node = ast.Module(
             body=[
                 self._generate_python_library_ast_node(name="lib"),
-                self._generate_python_binary_wrapper_node(
+                self._generate_pex_binary_wrapper_node(
                     "alembic", entry_point="alembic.config", dependencies=[":lib"]
                 ),
                 self._generate_migrations_python_app_ast_node(),

--- a/pypants/build_targets/python_package.py
+++ b/pypants/build_targets/python_package.py
@@ -271,15 +271,15 @@ class PythonPackage(BuildTarget):
         )
         return node
 
-    def _generate_python_binary_wrapper_node(
+    def _generate_pex_binary_wrapper_node(
         self,
         name: str,
         entry_point: Optional[str] = None,
         dependencies: Optional[List[str]] = None,
     ) -> ast.Expr:
-        """Generate an AST node for a python_binary Pants target with an entry point
+        """Generate an AST node for a pex_binary Pants target with an entry point
 
-        See: https://www.pantsbuild.org/python_readme.html#python_binary-entry_point
+        See: https://www.pantsbuild.org/python_readme.html#pex_binary-entry_point
 
         Args:
             name: Name of the binary, e.g. unittest
@@ -296,7 +296,7 @@ class PythonPackage(BuildTarget):
 
         node = ast.Expr(
             value=ast.Call(
-                func=ast.Name(id="python_binary"),
+                func=ast.Name(id="pex_binary"),
                 args=[],
                 keywords=[
                     ast.keyword(arg="name", value=ast.Str(name)),

--- a/pypants/config.py
+++ b/pypants/config.py
@@ -31,7 +31,6 @@ class Config:
         generate_build_file = <bool>
         generate_local_binary = <bool>
         generate_pytest_binary = <bool>
-        include_test_coverage = <bool>
         type = "library"|"binary"|...
 
     Instantiating this class will load and initialize a config parser instance.
@@ -125,23 +124,16 @@ class Config:
 
     @property
     def generate_local_binary(self) -> bool:
-        """Flag denoting whether to generate a python_binary target for local.py"""
+        """Flag denoting whether to generate a pex_binary target for local.py"""
         return self._config.getboolean(
             "package", "generate_local_binary", fallback=False
         )
 
     @property
     def generate_pytest_binary(self) -> bool:
-        """Flag denoting whether to include a python_binary target for pytest"""
+        """Flag denoting whether to include a pex_binary target for pytest"""
         return self._config.getboolean(
             "package", "generate_pytest_binary", fallback=False
-        )
-
-    @property
-    def include_test_coverage(self) -> bool:
-        """Flag denoting whether to include a coverage attribute on pytest targets"""
-        return self._config.getboolean(
-            "package", "include_test_coverage", fallback=True
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypants"
-version = "1.30.5"
+version = "2.0.2"
 description = "CLI for working with Python packages and BUILD files in a Pants monorepo"
 authors = ["Jonathan Drake <jdrake@narrativescience.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
# Overview:
This PR adds the support for pants 2.0.2. 
* python_binary target -> pex_binary
* removes test coverage option from build files as it is no longer supported
* Update docs and config